### PR TITLE
Easy-to-configure TLS and Mutual TLS client connections

### DIFF
--- a/src/main/java/mousio/client/exceptions/SecurityContextException.java
+++ b/src/main/java/mousio/client/exceptions/SecurityContextException.java
@@ -1,0 +1,10 @@
+package mousio.client.exceptions;
+
+/**
+ * Encapsulate all SslContext builder exceptions.
+ */
+public class SecurityContextException extends Exception {
+    public SecurityContextException(Throwable e) {
+        super(e);
+    }
+}

--- a/src/main/java/mousio/etcd4j/security/SecurityContextBuilder.java
+++ b/src/main/java/mousio/etcd4j/security/SecurityContextBuilder.java
@@ -1,0 +1,144 @@
+package mousio.etcd4j.security;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import mousio.client.exceptions.SecurityContextException;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.KeyStore;
+
+/**
+ * Easy-to-use SslContext builder for etcd clients
+ */
+public final class SecurityContextBuilder {
+    public static final String KEYSTORE_JKS = "JKS";
+
+    /**
+     * Builds SslContext using a protected keystore file. Adequate for non-mutual TLS connections.
+     *
+     * @param keystorePath Path for keystore file
+     * @param keystorePassword Password for protected keystore file
+     * @return SslContext ready to use
+     * @throws SecurityContextException for any troubles building the SslContext
+     */
+    public static SslContext forKeystore(String keystorePath, String keystorePassword)
+            throws SecurityContextException {
+        return forKeystore(keystorePath, keystorePassword, "SunX509");
+    }
+
+    /**
+     * Builds SslContext using protected keystore file overriding default key manger algorithm. Adequate for non-mutual TLS connections.
+     *
+     * @param keystorePath Path for keystore file
+     * @param keystorePassword Password for protected keystore file
+     * @param keyManagerAlgorithm Algorithm for keyManager used to process keystorefile
+     * @return SslContext ready to use
+     * @throws SecurityContextException for any troubles building the SslContext
+     */
+    public static SslContext forKeystore(String keystorePath, String keystorePassword, String keyManagerAlgorithm)
+            throws SecurityContextException {
+
+        try {
+            return forKeystore(new FileInputStream(keystorePath), keystorePassword, keyManagerAlgorithm);
+        } catch (Exception e) {
+            throw new SecurityContextException(e);
+        }
+    }
+
+    /**
+     * Builds SslContext using protected keystore file overriding default key manger algorithm. Adequate for non-mutual TLS connections.
+     *
+     * @param keystore Keystore inputstream (file, binaries, etc)
+     * @param keystorePassword Password for protected keystore file
+     * @param keyManagerAlgorithm Algorithm for keyManager used to process keystorefile
+     * @return SslContext ready to use
+     * @throws SecurityContextException for any troubles building the SslContext
+     */
+    public static SslContext forKeystore(InputStream keystore, String keystorePassword, String keyManagerAlgorithm)
+            throws SecurityContextException {
+
+        try {
+            final KeyStore ks = KeyStore.getInstance(KEYSTORE_JKS);
+            final KeyManagerFactory kmf = KeyManagerFactory.getInstance(keyManagerAlgorithm);
+
+            ks.load(keystore, keystorePassword.toCharArray());
+            kmf.init(ks, keystorePassword.toCharArray());
+
+            SslContextBuilder ctxBuilder = SslContextBuilder.forClient().keyManager(kmf);
+            return ctxBuilder.build();
+        } catch (Exception e) {
+            throw new SecurityContextException(e);
+        }
+    }
+
+    /**
+     * Builds SslContext using protected keystore and truststores. Adequate for mutual TLS connections.
+     * @param keystorePath Path for keystore file
+     * @param keystorePassword Password for protected keystore file
+     * @param truststorePath Path for truststore file
+     * @param truststorePassword Password for protected truststore file
+     * @return SslContext ready to use
+     * @throws SecurityContextException
+     */
+    public static SslContext forKeystoreAndTruststore(String keystorePath, String keystorePassword, String truststorePath, String truststorePassword)
+            throws SecurityContextException {
+        return forKeystoreAndTruststore(keystorePath, keystorePassword, truststorePath, truststorePassword, "SunX509");
+    }
+
+    /**
+     * Builds SslContext using protected keystore and truststores. Adequate for mutual TLS connections.
+     * @param keystorePath Path for keystore file
+     * @param keystorePassword Password for protected keystore file
+     * @param truststorePath Path for truststore file
+     * @param truststorePassword Password for protected truststore file
+     * @param keyManagerAlgorithm Algorithm for keyManager used to process keystorefile
+     * @return SslContext ready to use
+     * @throws SecurityContextException
+     */
+    public static SslContext forKeystoreAndTruststore(String keystorePath, String keystorePassword, String truststorePath, String truststorePassword, String keyManagerAlgorithm)
+            throws SecurityContextException {
+
+        try {
+            return forKeystoreAndTruststore(new FileInputStream(keystorePath), keystorePassword, new FileInputStream(truststorePath), truststorePassword, keyManagerAlgorithm);
+        } catch (Exception e) {
+            throw new SecurityContextException(e);
+        }
+    }
+
+    /**
+     * Builds SslContext using protected keystore and truststores, overriding default key manger algorithm. Adequate for mutual TLS connections.
+     * @param keystore Keystore inputstream (file, binaries, etc)
+     * @param keystorePassword Password for protected keystore file
+     * @param truststore Truststore inputstream (file, binaries, etc)
+     * @param truststorePassword Password for protected truststore file
+     * @param keyManagerAlgorithm Algorithm for keyManager used to process keystorefile
+     * @return SslContext ready to use
+     * @throws SecurityContextException
+     */
+    public static SslContext forKeystoreAndTruststore(InputStream keystore, String keystorePassword, InputStream truststore, String truststorePassword, String keyManagerAlgorithm)
+            throws SecurityContextException {
+        try {
+            final KeyStore ks = KeyStore.getInstance(KEYSTORE_JKS);
+            final KeyStore ts = KeyStore.getInstance(KEYSTORE_JKS);
+
+            final KeyManagerFactory keystoreKmf = KeyManagerFactory.getInstance(keyManagerAlgorithm);
+            final TrustManagerFactory truststoreKmf = TrustManagerFactory.getInstance(keyManagerAlgorithm);
+
+            ks.load(keystore, keystorePassword.toCharArray());
+            ts.load(truststore, truststorePassword.toCharArray());
+
+            keystoreKmf.init(ks, keystorePassword.toCharArray());
+            truststoreKmf.init(ts);
+
+            SslContextBuilder ctxBuilder = SslContextBuilder.forClient().keyManager(keystoreKmf);
+            ctxBuilder.trustManager(truststoreKmf);
+
+            return ctxBuilder.build();
+        } catch (Exception e) {
+            throw new SecurityContextException(e);
+        }
+    }
+}

--- a/src/test/java/mousio/etcd4j/security/EtcdKeystoreTest.java
+++ b/src/test/java/mousio/etcd4j/security/EtcdKeystoreTest.java
@@ -1,0 +1,55 @@
+package mousio.etcd4j.security;
+
+import mousio.client.exceptions.SecurityContextException;
+import mousio.etcd4j.EtcdClient;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+
+public class EtcdKeystoreTest {
+    private final String KS_PASSWORD = "dummy_password";
+    private final String KS_LOCATION = "dummy_ks";
+    private final String TS_LOCATION = "dumy_ts";
+
+    @Test(expected = SecurityContextException.class)
+    public void testInvalidKeystoreLocation() throws SecurityContextException {
+        SecurityContextBuilder.forKeystore(KS_LOCATION, KS_PASSWORD);
+    }
+
+    @Test(expected = SecurityContextException.class)
+    public void testInvalidTruststoreLocation() throws SecurityContextException {
+        SecurityContextBuilder.forKeystoreAndTruststore(KS_LOCATION, KS_PASSWORD, TS_LOCATION, KS_PASSWORD);
+    }
+
+    @Test(expected = SecurityContextException.class)
+    public void testInvalidKeystoreFormat() throws UnsupportedEncodingException, SecurityContextException {
+        InputStream stream = new ByteArrayInputStream("bad_format_keystore".getBytes(StandardCharsets.UTF_8.name()));
+        SecurityContextBuilder.forKeystore(stream, KS_PASSWORD, "SunX509");
+    }
+
+    @Test(expected = SecurityContextException.class)
+    public void testInvalidTruststoreFormat() throws UnsupportedEncodingException, SecurityContextException {
+        InputStream stream = new ByteArrayInputStream("bad_format_keystore".getBytes(StandardCharsets.UTF_8.name()));
+        SecurityContextBuilder.forKeystoreAndTruststore(stream, KS_PASSWORD, stream, KS_PASSWORD, "SunX509");
+    }
+
+    @Ignore
+    @Test
+    public void testVersion() throws SecurityContextException, URISyntaxException {
+        EtcdClient etcd = new EtcdClient(SecurityContextBuilder.forKeystoreAndTruststore(
+                "/keystore.jks",
+                "g6fNa4JsFRJq0KgJdMqpagCrER3Jk29fVKQJtDZV",
+                "/stratio/secrets/megadev/truststore.jks",
+                "QPkS0cuzK8xmxSjW4yPQes8rd0ben7xy42Enuvj5"
+        ), new URI("https://127.0.0.1:2379"));
+
+        System.out.println(etcd.version());
+    }
+
+}


### PR DESCRIPTION
Provides support for TLS connections to etcd (non mutual and mutual TLS) by using Java's Truststore and Keystore mechanisms. Etcd clients can now be configured as follows

```java
EtcdClient etcd = new EtcdClient(SecurityContextBuilder.forKeystoreAndTruststore(
"/keystore.jks",
"keystore_pass",
"/truststore.jks",
"truststore_pass"
), new URI("https://127.0.0.1:2379"));
```